### PR TITLE
revise info on Safari's handling of list-style

### DIFF
--- a/files/en-us/web/css/list-style/index.html
+++ b/files/en-us/web/css/list-style/index.html
@@ -73,7 +73,11 @@ list-style: unset;
 
 <h2 id="Accessibility_concerns">Accessibility concerns</h2>
 
-<p>Safari has an issue whereby unordered lists with a <code>list-style</code> value of <code>none</code> applied to them will not be recognized as a list in the accessibility tree. To address this, add a <a href="https://en.wikipedia.org/wiki/Zero-width_space">zero-width space</a> as <a href="/en-US/docs/Web/CSS/content">pseudo-content</a> before each list item to ensure the list is recognized properly. This ensures the design is unaffected by the bug fix and that list items are not improperly described.</p>
+<p>In a notable exception, Safari will not recognize an unordered list as a list in the accessibility tree if has a <code>list-style</code> value of <code>none</code>.</p>
+
+<p>The most straightforward way to address this is to add an explicit <code>role="list"</code> to the <code><ul></code> element in the markup. This will restore the list semantics without affecting the design.</p>
+
+<p>CSS-only workarounds are also available for those who do not have access to the markup. One is to add a <a href="https://en.wikipedia.org/wiki/Zero-width_space">zero-width space</a> as <a href="/en-US/docs/Web/CSS/content">pseudo-content</a> before each list item:</p>
 
 <pre class="brush: css">ul {
   list-style: none;
@@ -84,8 +88,27 @@ ul li::before {
 }
 </pre>
 
+<p>A second approach is to apply a url value to the list-style property:</p>
+
+
+
+<pre class="brush: css">
+nav ol, nav ul {
+  list-style: none;
+}
+
+/* becomes */
+
+nav ol, nav ul {
+  list-style: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E");
+}
+</pre>
+
+<p>These CSS workarounds should be used only when the HTML solution is not available, and only after testing to ensure that they don’t result in unexpected behaviors that may negatively impact users’ experiences.</p>
+
 <ul>
- <li><a href="https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/">VoiceOver and list-style-type: none – Unfettered Thoughts</a></li>
+  <li><a href="https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html">'Fixing' Lists</a></li>
+  <li><a href="https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/">VoiceOver and list-style-type: none – Unfettered Thoughts</a></li>
  <li><a href="/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.3_%E2%80%94_Create_content_that_can_be_presented_in_different_ways">MDN Understanding WCAG, Guideline 1.3 explanations</a></li>
  <li><a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html" rel="noopener">Understanding Success Criterion 1.3.1 | W3C Understanding WCAG 2.0</a></li>
 </ul>


### PR DESCRIPTION
This refines the info on Safari's handling of `list-style="none"` and suggested workarounds for the same.